### PR TITLE
Add ContextContainer.rootThread

### DIFF
--- a/src/main/java/xyz/wagyourtail/jsmacros/core/language/ContextContainer.java
+++ b/src/main/java/xyz/wagyourtail/jsmacros/core/language/ContextContainer.java
@@ -3,19 +3,23 @@ package xyz.wagyourtail.jsmacros.core.language;
 import xyz.wagyourtail.jsmacros.core.Core;
 import xyz.wagyourtail.jsmacros.core.MethodWrapper;
 
-import java.util.function.Consumer;
-
 /**
  * @param <T>
  * @since 1.4.0
  */
 public class ContextContainer<T> {
     private final ScriptContext<T> ctx;
+    private final Thread rootThread;
     private Thread lockThread;
     private boolean locked = true;
-    
+
     public ContextContainer(ScriptContext<T> ctx) {
+        this(ctx, Thread.currentThread());
+    }
+
+    public ContextContainer(ScriptContext<T> ctx, Thread rootThread) {
         this.ctx = ctx;
+        this.rootThread = rootThread;
     }
 
     public synchronized boolean isLocked() {
@@ -33,6 +37,10 @@ public class ContextContainer<T> {
     
     public Thread getLockThread() {
         return lockThread;
+    }
+
+    public Thread getRootThread() {
+        return rootThread;
     }
     
     /**

--- a/src/main/java/xyz/wagyourtail/jsmacros/core/library/impl/FJsMacros.java
+++ b/src/main/java/xyz/wagyourtail/jsmacros/core/library/impl/FJsMacros.java
@@ -323,7 +323,7 @@ public class FJsMacros extends BaseLibrary {
             throw new IllegalThreadStateException("must explicitly release context (un-joins joined events) using 'context.releaseLock()' if you want to wait for a new event on this script's main thread!");
         }
         ScriptContext<?> ctx = Core.instance.threadContext.get(th);
-        ContextContainer<?> ctxCont = new ContextContainer<>(ctx);
+        ContextContainer<?> ctxCont = new ContextContainer<>(ctx, cc == null ? th : cc.getRootThread());
         ctxCont.setLockThread(th);
         Core.instance.eventContexts.put(th, ctxCont);
         Semaphore lock = new Semaphore(0);


### PR DESCRIPTION
To workaround waitForEvent replacing the current context which replaces the lock thread.

Idk if this is the best way to approach this problem, please let me know