### PR TITLE
Fix single capitalization error in the general page

### DIFF
--- a/docs/web/general.html
+++ b/docs/web/general.html
@@ -43,7 +43,7 @@
         href="xyz/wagyourtail/jsmacros/core/library/impl/FReflection.html">Reflection library</a>.
     <br>
     <br>
-    you can find some reference on the difference between the JS embedded in Java and Node.js specifications <a
+    You can find some reference on the difference between the JS embedded in Java and Node.js specifications <a
         href="https://www.graalvm.org/reference-manual/js/NodeJSvsJavaScriptContext/" target="_blank">here</a>.
     mainly:
     <div id="quote">


### PR DESCRIPTION
In the general page of the documentation, there is a singular capitalization error, which I have fixed in my fork